### PR TITLE
Make 'build' and 'install --root' work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ fileobj ([v0.7.23](https://github.com/kusumi/fileobj/releases/tag/v0.7.23))
         $ python --version
         Python 2.6.6
         $ sudo python ./setup.py install --force --record ./install.out
+        $ sudo python ./check.py
         $ fileobj --version
         v0.7.23
         $ fileobj
@@ -49,6 +50,7 @@ fileobj ([v0.7.23](https://github.com/kusumi/fileobj/releases/tag/v0.7.23))
         $ python3 --version
         Python 3.3.1
         $ sudo python3 ./setup.py install --force --record ./install.out
+        $ sudo python3 ./check.py
         $ fileobj --version
         v0.7.23
         $ fileobj

--- a/check.py
+++ b/check.py
@@ -1,0 +1,24 @@
+if __name__ == '__main__':
+    import os
+    import sys
+
+    import src.nodep
+    src.nodep.test()
+
+    import fileobj.package
+    import fileobj.version
+    l = []
+    for d in fileobj.package.get_paths():
+        for x in fileobj.package.iter_module_name():
+            s = x[len(fileobj.package.get_prefix()):]
+            s = s.replace(".", "/") + ".py"
+            a = os.path.join(d, s)
+            b = os.path.join("./src", s)
+            if os.path.isfile(a) and not os.path.isfile(b):
+                l.append(a)
+    if l:
+        for f in l:
+            sys.stderr.write("### %s has no such file %s\n" %
+                (fileobj.version.get_version_string(), f))
+        sys.stderr.write("### Prefer uninstalling older version if exists\n")
+        sys.exit(2)

--- a/setup.py
+++ b/setup.py
@@ -26,21 +26,3 @@ if __name__ == '__main__':
         scripts     = ["script/fileobj"],
         packages    = ["fileobj", "fileobj.ext"],
         package_dir = {"fileobj" : "src", "fileobj.ext" : "src/ext",})
-
-    import fileobj.package
-    import fileobj.version
-    l = []
-    for d in fileobj.package.get_paths():
-        for x in fileobj.package.iter_module_name():
-            s = x[len(fileobj.package.get_prefix()):]
-            s = s.replace(".", "/") + ".py"
-            a = os.path.join(d, s)
-            b = os.path.join("./src", s)
-            if os.path.isfile(a) and not os.path.isfile(b):
-                l.append(a)
-    if l:
-        for f in l:
-            sys.stderr.write("### %s has no such file %s\n" %
-                (fileobj.version.get_version_string(), f))
-        sys.stderr.write("### Prefer uninstalling older version if exists\n")
-        sys.exit(2)


### PR DESCRIPTION
This moves the checking to a separate file so that we can ensure that it
will not be called before it is succesfully installed into the system.
